### PR TITLE
Add log rotation to Docker services

### DIFF
--- a/docker/full-elestio.yml
+++ b/docker/full-elestio.yml
@@ -11,6 +11,13 @@ services:
     image: postgres:15
     restart: unless-stopped
     networks: [chaingraph]
+    # Note: Docker doesn't support time-based log retention.
+    # Use size/file-based rotation to keep logs bounded.
+    logging:
+      driver: local
+      options:
+        max-size: "10m"
+        max-file: "3"
     env_file:
       - ../.env
     environment:
@@ -33,6 +40,12 @@ services:
         condition: service_healthy
     restart: unless-stopped
     networks: [chaingraph]
+    # Bound container logs to prevent disk growth
+    logging:
+      driver: local
+      options:
+        max-size: "10m"
+        max-file: "3"
     env_file:
       - ../.env
     ports:
@@ -77,6 +90,12 @@ services:
       "
     restart: unless-stopped
     networks: [chaingraph]
+    # Bound container logs to prevent disk growth
+    logging:
+      driver: local
+      options:
+        max-size: "10m"
+        max-file: "3"
     depends_on:
       - db
       - hasura


### PR DESCRIPTION
Configured local logging with size and file limits for postgres, hasura, and chaingraph services in full-elestio.yml to prevent unbounded disk usage from container logs.